### PR TITLE
List without image restriction

### DIFF
--- a/Resources/views/Admin/file_list.html.twig
+++ b/Resources/views/Admin/file_list.html.twig
@@ -2,7 +2,7 @@
     {% block field %}
         {% spaceless %}
             <div class="pull-left span1">
-                {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
+                {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') and object.file != null %}
                     <img src="{{ asset(object.file.path) }}">
                 {% endif %}
             </div>


### PR DESCRIPTION
if you create a object without image, in the list preview, it shows a error:

```
Impossible to access an attribute ("path") on a NULL variable ("") in SopinetUploadFilesBundle:Admin:file_list.html.twig at line 6
```
